### PR TITLE
Fix zero vector handling in nearest

### DIFF
--- a/empathic_embeddings.py
+++ b/empathic_embeddings.py
@@ -183,7 +183,12 @@ class EmpathicSpace:
         # Same embedding, but affect dimension sign-flipped
         return np.concatenate([self.E[w], [-self.alpha * self.val[self.w2i[w]]]])
     def nearest(self, vec: np.ndarray, n: int = 5) -> List[Tuple[str, float]]:
-        v = vec / np.linalg.norm(vec)
+        norm = np.linalg.norm(vec)
+        if norm < 1e-12:
+            # If the query vector has zero norm (e.g., phrase with no known
+            # tokens), return neutral similarities instead of NaNs.
+            return [(w, 0.0) for w in self.words][:n]
+        v = vec / norm
         return sorted(((w, float(v.dot(u))) for w, u in self.store.items()),
                       key=lambda t: -t[1])[:n]
 


### PR DESCRIPTION
## Summary
- handle zero input vectors gracefully in EmpathicSpace.nearest

## Testing
- `python empathic_embeddings.py`
- `python - <<'EOF'
from empathic_embeddings import EmpathicSpace
import numpy as np
E = {'a': np.array([1.,0.],dtype=np.float32), 'b': np.array([0.,1.],dtype=np.float32)}
space = EmpathicSpace(E, gold={'a':[1,0,0],'b':[0,1,0]})
print(space.nearest(np.zeros(3)))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687ad54d55f88323ac7335291579743d