### PR TITLE
Fix model loading and nearest neighbour search

### DIFF
--- a/empathic_embeddings.py
+++ b/empathic_embeddings.py
@@ -209,7 +209,9 @@ class EmpathicSpace:
         v = vec / norm
         sims = self._store_matrix @ v
         n = min(n, len(self.words))
-        idxs = np.argpartition(-sims, range(n))[:n]
+        if n <= 0:
+            return []
+        idxs = np.argpartition(-sims, n - 1)[:n]
         idxs = idxs[np.argsort(-sims[idxs])]
         return [(self.words[i], float(sims[i])) for i in idxs]
 
@@ -547,6 +549,7 @@ class EmpathicSpace:
         n = len(obj.words)
         obj.L_plus = obj.L_minus = sp.eye(n, dtype=np.float64)
         obj.store = {w: obj.vector(w) / np.linalg.norm(obj.vector(w)) for w in obj.words}
+        obj._store_matrix = np.vstack([obj.store[w] for w in obj.words])
         # Re-initialize composition parameters after loading
         mean_vec_norm = np.mean([np.linalg.norm(v) for v in obj.E.values()])
         mean_vec_norm = mean_vec_norm if mean_vec_norm > 0 else 1.0


### PR DESCRIPTION
## Summary
- Guard nearest-neighbour search against empty requests and simplify `argpartition` call
- Rebuild internal search matrix when loading saved models

## Testing
- `python -m py_compile empathic_embeddings.py`
- `python - <<'PY'
import empathic_embeddings as ee
E = { 'happy': ee.np.array([1.0,0.0]), 'sad': ee.np.array([-1.0,0.0]) }
VAD = { 'happy':[1,0,0], 'sad':[0,0,0] }
space = ee.EmpathicSpace(E, gold=VAD)
space.save('tmpmodel.json')
loaded = ee.EmpathicSpace.load('tmpmodel.json', 'vecfile.txt')
print('nearest after load:', loaded.nearest(loaded.vector('happy'), n=2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a61724fa3c8323bf8975a3534b8c8e